### PR TITLE
ci: remove redundant job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,13 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  commits:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: webiny/action-conventional-commits@v1.1.0
-
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
* the conventional commit check runs as a separate job already, must have been left here as an accident 