### PR TITLE
feat: enter password through ui

### DIFF
--- a/source/log/log_repository_crypto_applyer.hpp
+++ b/source/log/log_repository_crypto_applyer.hpp
@@ -37,6 +37,9 @@ class LogRepositoryCryptoApplier {
     static constexpr auto encryptetLogRepoMarkerFile = ".cle";
     static void apply(const std::string &password, const std::filesystem::path &logDirPath,
                       const std::string &logFilenameFormat, Crypto crypto);
+    static bool isEncrypted(const std::filesystem::path &logDirPath);
+    static bool isDecryptionPasswordValid(const std::filesystem::path &logDirPath,
+                                          const std::string &password);
 
   private:
     LogRepositoryCryptoApplier() {}


### PR DESCRIPTION
Password can be entered trough cli using `--password` option. But it would be nice if the user would be prompted to enter the password when caps log starts and detects an encrypted repo with no password provided. 