### PR TITLE
fix: throw on non existing ssh key paths

### DIFF
--- a/source/utils/git_repo.cpp
+++ b/source/utils/git_repo.cpp
@@ -66,12 +66,20 @@ bool hasChangedFiles(git_repository *repo) {
 
     return status_count > 0;
 }
-GitRepo::GitRepo(const std::filesystem::path &path, std::string sshKeyPath,
-                 std::string sshPubKeyPath, std::string remoteName, std::string mainBranchName)
+GitRepo::GitRepo(const std::filesystem::path &path, const std::filesystem::path &sshKeyPath,
+                 const std::filesystem::path &sshPubKeyPath, std::string remoteName,
+                 std::string mainBranchName)
     : m_remoteName{std::move(remoteName)}, m_mainBranchName{std::move(mainBranchName)},
-      m_sshKeyPath{std::move(sshKeyPath)}, m_sshPubKeyPath{std::move(sshPubKeyPath)} {
+      m_sshKeyPath{sshKeyPath}, m_sshPubKeyPath{sshPubKeyPath} {
     if (m_sshKeyPath.empty() || m_sshPubKeyPath.empty()) {
         throw std::invalid_argument{"SSH keys are not set!"};
+    }
+    if (not std::filesystem::exists(m_sshKeyPath)) {
+        throw std::invalid_argument{"SSH key does not exist: " + m_sshKeyPath};
+    }
+    if (not std::filesystem::exists(m_sshPubKeyPath)) {
+        throw std::invalid_argument{std::string{"SSH public key does not exist: "} +
+                                    m_sshPubKeyPath};
     }
     if (m_remoteName.empty()) {
         throw std::invalid_argument{"Remote name can not be empty!"};

--- a/source/utils/git_repo.hpp
+++ b/source/utils/git_repo.hpp
@@ -19,8 +19,9 @@ class GitRepo {
     std::string m_sshKeyPath;
 
   public:
-    GitRepo(const std::filesystem::path &path, std::string sshKeyPath, std::string sshPubKeyPath,
-            std::string remoteName = "origin", std::string mainBranchName = "master");
+    GitRepo(const std::filesystem::path &path, const std::filesystem::path &sshKeyPath,
+            const std::filesystem::path &sshPubKeyPath, std::string remoteName = "origin",
+            std::string mainBranchName = "master");
 
     GitRepo(const GitRepo &) = delete;
     GitRepo(GitRepo &&) noexcept;


### PR DESCRIPTION
If this is not caught earlier, caps log hangs on "pulling from remote..." loading screen.