### PR TITLE
build: use commit id for version when unspecified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,23 @@
 cmake_minimum_required(VERSION 3.14)
 
-# If version number is not provided, just use a dummy
+# If version number is not provided, use commit id.
 if(NOT CAPS_LOG_VERSION)
-    set(CAPS_LOG_VERSION "development")
+  find_package(Git)
+  if(Git_FOUND)
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+      OUTPUT_VARIABLE CAPS_LOG_COMMIT_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  else()
+    set(CAPS_LOG_COMMIT_ID "NOT_FOUND")
+  endif()
+  set(CAPS_LOG_VERSION "commit-${CAPS_LOG_COMMIT_ID}")
 endif()
 
+message(STATUS "Captain's Log version: ${CAPS_LOG_VERSION}")
+
 # Project setup
-project(caps-log
-    LANGUAGES CXX
-)
+project(caps-log LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,24 +27,27 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 include(FetchContent)
 
 # -------------------------- Fetech ftxui ------------------------------- #
- 
+
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
-FetchContent_Declare(ftxui
-    GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-    GIT_TAG v5.0.0
-)
+FetchContent_Declare(
+  ftxui
+  GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
+  GIT_TAG v5.0.0)
 FetchContent_GetProperties(ftxui)
 if(NOT ftxui_POPULATED)
-    FetchContent_Populate(ftxui)
-    add_subdirectory(${ftxui_SOURCE_DIR} ${ftxui_BINARY_DIR} EXCLUDE_FROM_ALL)
+  FetchContent_Populate(ftxui)
+  add_subdirectory(${ftxui_SOURCE_DIR} ${ftxui_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 # --------------------------------- boost -------------------------------- #
-set(Boost_USE_STATIC_LIBS   ON)
-find_package(Boost 1.40 COMPONENTS program_options REQUIRED)
+set(Boost_USE_STATIC_LIBS ON)
+find_package(
+  Boost 1.40
+  COMPONENTS program_options
+  REQUIRED)
 
 if(NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost Not found")
+  message(FATAL_ERROR "Boost Not found")
 endif()
 
 # ------------------------------- OpenSSL -------------------------------- #
@@ -49,23 +61,23 @@ set(BUILD_SHARED_LIBS OFF)
 find_package(LibGit2 3 REQUIRED)
 
 # ------------------------------- Fetch FMT ------------------------------ #
- 
-FetchContent_Declare(fmt
-    GIT_REPOSITORY https://github.com/fmtlib/fmt
-    GIT_TAG 9.1.0
-)
+
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt
+  GIT_TAG 9.1.0)
 FetchContent_GetProperties(fmt)
 if(NOT fmt_POPULATED)
-    FetchContent_Populate(fmt)
-    add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
+  FetchContent_Populate(fmt)
+  add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 # --------------------------------- tests -------------------------------- #
 
 if(${CAPS_LOG_BUILD_TESTS})
-    message("Tests will be built")
-    include(CTest)
-    add_subdirectory(./test)
+  message("Tests will be built")
+  include(CTest)
+  add_subdirectory(./test)
 endif()
 
 # ------------------------------ caps-log -------------------------------- #

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,56 +1,51 @@
 add_executable(
-    caps-log
-
-    config.cpp
-    config.hpp
-    main.cpp
-
-    ./log/annual_log_data.cpp
-    ./log/annual_log_data.hpp
-    ./log/local_log_repository.cpp
-    ./log/local_log_repository.hpp
-    ./log/log_file.cpp
-    ./log/log_file.hpp
-    ./log/log_repository_base.hpp
-    ./log/log_repository_crypto_applier.cpp
-    ./log/log_repository_crypto_applier.hpp
-
-    ./utils/crypto.cpp
-    ./utils/crypto.hpp
-    ./utils/date.hpp
-    ./utils/string.hpp
-    ./utils/task_executor.hpp
-    ./utils/git_repo.cpp
-    ./utils/git_repo.hpp
-
-    ./view/annual_view.cpp
-    ./view/annual_view.hpp
-    ./view/annual_view_base.hpp
-    ./view/calendar_component.cpp
-    ./view/calendar_component.hpp
-    ./view/ftxui_ext/extended_containers.cpp
-    ./view/ftxui_ext/extended_containers.hpp
-    ./view/input_handler.hpp
-    ./view/preview.cpp
-    ./view/preview.hpp
-    ./view/promptable.cpp
-    ./view/promptable.hpp
-)
+  caps-log
+  config.cpp
+  config.hpp
+  main.cpp
+  ./log/annual_log_data.cpp
+  ./log/annual_log_data.hpp
+  ./log/local_log_repository.cpp
+  ./log/local_log_repository.hpp
+  ./log/log_file.cpp
+  ./log/log_file.hpp
+  ./log/log_repository_base.hpp
+  ./log/log_repository_crypto_applier.cpp
+  ./log/log_repository_crypto_applier.hpp
+  ./utils/crypto.cpp
+  ./utils/crypto.hpp
+  ./utils/date.hpp
+  ./utils/string.hpp
+  ./utils/task_executor.hpp
+  ./utils/git_repo.cpp
+  ./utils/git_repo.hpp
+  ./view/annual_view.cpp
+  ./view/annual_view.hpp
+  ./view/annual_view_base.hpp
+  ./view/calendar_component.cpp
+  ./view/calendar_component.hpp
+  ./view/ftxui_ext/extended_containers.cpp
+  ./view/ftxui_ext/extended_containers.hpp
+  ./view/input_handler.hpp
+  ./view/preview.cpp
+  ./view/preview.hpp
+  ./view/promptable.cpp
+  ./view/promptable.hpp)
 
 target_include_directories(caps-log PRIVATE ./ ${CMAKE_CURRENT_BINARY_DIR})
 
+target_link_libraries(
+  caps-log
+  ftxui::screen
+  ftxui::dom
+  ftxui::component
+  fmt::fmt
+  Boost::program_options
+  OpenSSL::Crypto
+  OpenSSL::SSL
+  ${LIBGIT2_LIBRARIES})
 
-target_link_libraries(caps-log
-    ftxui::screen
-    ftxui::dom
-    ftxui::component 
-    fmt::fmt
-    Boost::program_options
-    OpenSSL::Crypto
-    OpenSSL::SSL
-    ${LIBGIT2_LIBRARIES}
-)
-
-target_compile_definitions(caps-log PRIVATE CAPS_LOG_VERSION_STRING="${CAPS_LOG_VERSION}")
+target_compile_definitions(
+  caps-log PRIVATE CAPS_LOG_VERSION_STRING="${CAPS_LOG_VERSION}")
 
 install(TARGETS caps-log DESTINATION "bin")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,60 +3,55 @@
 set(INSTALL_GTEST OFF)
 
 FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  googletest
+  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 # --------------------------------- tests -------------------------------- #
 
-
 add_executable(
-    tests
-    ./config_test.cpp
-    ./controler_test.cpp
-    ./local_log_repository_test.cpp
-    ./log_entry_test.cpp
-    ./annual_log_data_test.cpp
-    ./calendar_component_test.cpp
-
-    ./../source/config.cpp
-    ./../source/log/log_file.cpp
-    ./../source/log/log_repository_crypto_applier.cpp
-    ./../source/log/local_log_repository.cpp
-    ./../source/log/annual_log_data.cpp
-    ./../source/view/calendar_component.cpp
-    ./../source/view/ftxui_ext/extended_containers.cpp
-    ./../source/utils/crypto.cpp
-    ./../source/utils/git_repo.cpp
-)
+  tests
+  ./config_test.cpp
+  ./controler_test.cpp
+  ./local_log_repository_test.cpp
+  ./log_entry_test.cpp
+  ./annual_log_data_test.cpp
+  ./calendar_component_test.cpp
+  ./../source/config.cpp
+  ./../source/log/log_file.cpp
+  ./../source/log/log_repository_crypto_applier.cpp
+  ./../source/log/local_log_repository.cpp
+  ./../source/log/annual_log_data.cpp
+  ./../source/view/calendar_component.cpp
+  ./../source/view/ftxui_ext/extended_containers.cpp
+  ./../source/utils/crypto.cpp
+  ./../source/utils/git_repo.cpp)
 
 target_link_libraries(
-    tests
-    gtest_main
-    gmock_main
-    ftxui::screen
-    ftxui::dom
-    ftxui::component 
-    fmt::fmt
-    Boost::program_options
-    OpenSSL::Crypto
-    OpenSSL::SSL
-    ${LIBGIT2_LIBRARIES}
-)
+  tests
+  gtest_main
+  gmock_main
+  ftxui::screen
+  ftxui::dom
+  ftxui::component
+  fmt::fmt
+  Boost::program_options
+  OpenSSL::Crypto
+  OpenSSL::SSL
+  ${LIBGIT2_LIBRARIES})
 
-target_include_directories(
-    tests
-    PRIVATE
-    ../source/
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+target_include_directories(tests PRIVATE ../source/ ${CMAKE_CURRENT_BINARY_DIR})
 
-target_compile_definitions(tests PRIVATE CAPS_LOG_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/test/data")
-target_compile_definitions(tests PRIVATE CAPS_LOG_VERSION_STRING="${CAPS_LOG_VERSION}")
+target_compile_definitions(
+  tests PRIVATE CAPS_LOG_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/test/data")
+target_compile_definitions(
+  tests PRIVATE CAPS_LOG_VERSION_STRING="${CAPS_LOG_VERSION}")
 
 include(GoogleTest)
 gtest_discover_tests(tests)


### PR DESCRIPTION

This makes the output of `caps-log --help` shows the commit id from which 
the caps-log was built, if the CAPS_LOG_VERSION is not specified. 
Since manual building of the executable is encouraged, this will help in case of potential bug reports 
to identify the "version" of the app. 

Also, cmake is formated with `cmake-format` 

```
...
Capstains Log (caps-log)! A CLI journalig tool.
Version: development 
...
```

```
...
Capstains Log (caps-log)! A CLI journalig tool.
Version: commit-5f326bf3e9722da02808245a6661151a69e5b290
...
```