### PR TITLE
fix: dont use uninitialized repo obj

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -68,7 +68,7 @@ auto makeCapsLog(const caps_log::Config &conf) {
     }();
 
     return caps_log::App{std::move(view), std::move(repo), std::move(editor),
-                         conf.ignoreFirstLineWhenParsingSections, std::move(*gitRepo)};
+                         conf.ignoreFirstLineWhenParsingSections, std::move(gitRepo)};
 }
 
 int main(int argc, const char **argv) try {


### PR DESCRIPTION
fixes #56 