### PR TITLE
refactor: remove annual log map

### DIFF
--- a/source/log/annual_log_data.hpp
+++ b/source/log/annual_log_data.hpp
@@ -2,7 +2,10 @@
 
 #include "log_repository_base.hpp"
 #include "utils/date.hpp"
+#include <chrono>
 #include <memory>
+#include <set>
+#include <string>
 
 namespace caps_log::log {
 
@@ -13,9 +16,9 @@ namespace caps_log::log {
  */
 class AnnualLogData {
   public:
-    utils::date::AnnualMap<bool> logAvailabilityMap;
-    utils::date::StringYearMap sectionMap;
-    utils::date::StringYearMap tagMap;
+    utils::date::Dates datesWithLogs;
+    std::map<std::string, utils::date::Dates> datesWithSection;
+    std::map<std::string, utils::date::Dates> datesWithTag;
 
     /**
      * Constructs YearOverviewData from logs in a given year.

--- a/source/utils/date.hpp
+++ b/source/utils/date.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <iomanip>
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -27,6 +28,10 @@ inline std::tm dateToTm(const std::chrono::year_month_day &date) {
 }
 
 } // namespace detail
+
+inline std::chrono::month_day monthDay(std::chrono::year_month_day date) {
+    return std::chrono::month_day{date.month(), date.day()};
+}
 
 inline std::string formatToString(const std::chrono::year_month_day &date,
                                   const std::string &format = "%d. %m. %y.") {
@@ -85,47 +90,6 @@ inline std::string getStringNameForMonth(std::chrono::month month) {
     return kMonthNames.at(index);
 }
 
-/**
- * A type of "map" container that maps dates in one year to T
- **/
-template <typename T> class AnnualMap {
-    static constexpr auto kDaysInMonth = 31;
-    static constexpr auto kMonthsInYear = 12;
-    std::array<std::array<T, kDaysInMonth>, kMonthsInYear> m_map{};
-
-  public:
-    T &get(const std::chrono::year_month_day &date) {
-        return m_map[static_cast<unsigned>(date.month()) - 1]
-                    [static_cast<unsigned>(date.day()) - 1];
-    }
-    const T &get(const std::chrono::year_month_day &date) const {
-        return m_map[static_cast<unsigned>(date.month()) - 1]
-                    [static_cast<unsigned>(date.day()) - 1];
-    }
-    T &get(unsigned day, unsigned month) { return m_map[month - 1][day - 1]; }
-    const T &get(unsigned day, unsigned month) const { return m_map[month - 1][day - 1]; }
-
-    void set(const std::chrono::year_month_day &date, const T &value) {
-        m_map[static_cast<unsigned>(date.month()) - 1][static_cast<unsigned>(date.day()) - 1] =
-            value;
-    }
-    T &set(unsigned day, unsigned month, T &val) { return m_map[month - 1][day - 1] = val; }
-
-    inline unsigned daysSet() const {
-        unsigned result = 0;
-        for (const auto &month : m_map) {
-            result += std::count(month.begin(), month.end(), true);
-        }
-        return result;
-    }
-
-    inline bool hasAnyDaySet() const {
-        return std::ranges::any_of(m_map, [](const auto &month) {
-            return std::ranges::any_of(month, [](const auto &day) { return day; });
-        });
-    }
-};
-
-using StringYearMap = std::map<std::string, AnnualMap<bool>>;
+using Dates = std::set<std::chrono::month_day>;
 
 } // namespace caps_log::utils::date

--- a/source/view/annual_view.cpp
+++ b/source/view/annual_view.cpp
@@ -5,6 +5,7 @@
 #include "ftxui/component/screen_interactive.hpp"
 #include "ftxui/dom/elements.hpp"
 #include "ftxui_ext/extended_containers.hpp"
+#include "utils/date.hpp"
 #include "view/input_handler.hpp"
 #include "view/windowed_menu.hpp"
 
@@ -49,7 +50,7 @@ std::shared_ptr<Promptable> AnnualView::makeFullUIComponent() {
                 utils::date::formatToString(utils::date::getToday(), "%d. %m. %Y.");
             const auto titleText =
                 fmt::format("Today is: {} -- There are {} log entries for year {}.", dateStr,
-                            m_availabeLogsMap != nullptr ? m_availabeLogsMap->daysSet() : 0,
+                            m_datesWithLogs != nullptr ? m_datesWithLogs->size() : 0,
                             static_cast<int>(m_calendarButtons->getFocusedDate().year()));
             const auto mainSection =
                 hbox(m_tagsMenu->Render(), m_sectionsMenu->Render(), m_calendarButtons->Render());
@@ -85,7 +86,8 @@ CalendarOption AnnualView::makeCalendarOptions(const std::chrono::year_month_day
 
         if (today == date) {
             element = element | color(Color::Red);
-        } else if (m_highlightedLogsMap && m_highlightedLogsMap->get(date)) {
+        } else if (m_highlightedDates &&
+                   m_highlightedDates->contains(utils::date::monthDay(date))) {
             element = element | color(Color::Yellow);
         } else if (utils::date::isWeekend(date)) {
             element = element | color(Color::Blue);
@@ -95,8 +97,8 @@ CalendarOption AnnualView::makeCalendarOptions(const std::chrono::year_month_day
             element = element | inverted;
         }
 
-        if (m_availabeLogsMap) {
-            if (m_availabeLogsMap->get(date)) {
+        if (m_datesWithLogs) {
+            if (m_datesWithLogs->contains(utils::date::monthDay(date))) {
                 element = element | underlined;
             } else {
                 element = element | dim;

--- a/source/view/annual_view.hpp
+++ b/source/view/annual_view.hpp
@@ -28,8 +28,8 @@ class AnnualView : public AnnualViewBase {
     std::shared_ptr<Promptable> m_rootComponent;
 
     // Maps that help m_calendarButtons highlight certain logs.
-    const utils::date::AnnualMap<bool> *m_highlightedLogsMap = nullptr;
-    const utils::date::AnnualMap<bool> *m_availabeLogsMap = nullptr;
+    const utils::date::Dates *m_highlightedDates = nullptr;
+    const utils::date::Dates *m_datesWithLogs = nullptr;
 
     // Menu items for m_tagsMenu & m_sectionsMenu
     std::vector<std::string> m_tagMenuItems, m_sectionMenuItems;
@@ -54,12 +54,8 @@ class AnnualView : public AnnualViewBase {
 
     void setInputHandler(InputHandlerBase *handler) override { m_handler = handler; }
 
-    void setAvailableLogsMap(const utils::date::AnnualMap<bool> *map) override {
-        m_availabeLogsMap = map;
-    }
-    void setHighlightedLogsMap(const utils::date::AnnualMap<bool> *map) override {
-        m_highlightedLogsMap = map;
-    }
+    void setDatesWithLogs(const utils::date::Dates *map) override { m_datesWithLogs = map; }
+    void setHighlightedDates(const utils::date::Dates *map) override { m_highlightedDates = map; }
 
     void setTagMenuItems(std::vector<std::string> items) override {
         m_tagMenuItems = std::move(items);

--- a/source/view/annual_view_base.hpp
+++ b/source/view/annual_view_base.hpp
@@ -40,8 +40,9 @@ class AnnualViewBase { // NOLINT
 
     // passing only a pointer and having a view have no ownership of
     // the map allows for having precoputed maps and switching
-    virtual void setAvailableLogsMap(const utils::date::AnnualMap<bool> *map) = 0;
-    virtual void setHighlightedLogsMap(const utils::date::AnnualMap<bool> *map) = 0;
+    virtual void setDatesWithLogs(const utils::date::Dates *map) = 0;
+    virtual void setHighlightedDates(const utils::date::Dates *map) = 0;
+
     // can't use a pointer here because some FTXUI menu limitations
     virtual void setTagMenuItems(std::vector<std::string> items) = 0;
     virtual void setSectionMenuItems(std::vector<std::string> items) = 0;

--- a/test/annual_log_data_test.cpp
+++ b/test/annual_log_data_test.cpp
@@ -4,30 +4,36 @@
 #include "log/log_file.hpp"
 
 #include "mocks.hpp"
+#include "utils/date.hpp"
+
+namespace caps_log::log::test {
 
 TEST(YearOverviewDataTest, Collect) {
     const auto dummyDate = std::chrono::year_month_day{std::chrono::year{2020},
                                                        std::chrono::month{2}, std::chrono::day{3}};
     auto dummyRepo = std::make_shared<DummyRepository>();
     dummyRepo->write({dummyDate, "\n# dummy section\n * dummy tag"});
-    auto data = caps_log::log::AnnualLogData::collect(dummyRepo, dummyDate.year());
+    auto data = AnnualLogData::collect(dummyRepo, dummyDate.year());
 
     // inital collection
-    EXPECT_EQ(data.tagMap.size(), 1);
-    EXPECT_EQ(data.sectionMap.size(), 1);
-    EXPECT_EQ(data.logAvailabilityMap.daysSet(), 1);
-    EXPECT_EQ(data.logAvailabilityMap.get(dummyDate), true);
+    EXPECT_EQ(data.datesWithTag.size(), 1);
+    EXPECT_EQ(data.datesWithSection.size(), 1);
+    EXPECT_EQ(data.datesWithLogs.size(), 1);
+    EXPECT_EQ(data.datesWithLogs.contains(utils::date::monthDay(dummyDate)), true);
 
-    EXPECT_EQ(data.tagMap["dummy tag"].daysSet(), 1);
-    EXPECT_EQ(data.sectionMap["dummy section"].daysSet(), 1);
-    EXPECT_EQ(data.tagMap["dummy tag"].get(dummyDate), true);
-    EXPECT_EQ(data.sectionMap["dummy section"].get(dummyDate), true);
+    EXPECT_EQ(data.datesWithTag["dummy tag"].size(), 1);
+    EXPECT_EQ(data.datesWithSection["dummy section"].size(), 1);
+    EXPECT_EQ(data.datesWithTag["dummy tag"].contains(utils::date::monthDay(dummyDate)), true);
+    EXPECT_EQ(data.datesWithSection["dummy section"].contains(utils::date::monthDay(dummyDate)),
+              true);
 
     // collection after removal of a log entry
     dummyRepo->remove(dummyDate);
     data.collect(dummyRepo, dummyDate);
 
-    EXPECT_EQ(data.tagMap.size(), 0);
-    EXPECT_EQ(data.sectionMap.size(), 0);
-    EXPECT_EQ(data.logAvailabilityMap.daysSet(), 0);
+    EXPECT_EQ(data.datesWithTag.size(), 0);
+    EXPECT_EQ(data.datesWithSection.size(), 0);
+    EXPECT_EQ(data.datesWithLogs.size(), 0);
 }
+
+} // namespace caps_log::log::test

--- a/test/local_log_repository_test.cpp
+++ b/test/local_log_repository_test.cpp
@@ -240,6 +240,7 @@ TEST_F(LogRepoConstructionAfterCryptoApplier, ErrorOnEncryptedRepoWithBadPasswor
                                                 TMPDirPathProvider.getLogFilenameFormat(),
                                                 caps_log::Crypto::Encrypt);
 
-    EXPECT_THROW({ const auto repo = LocalLogRepository(TMPDirPathProvider, badPassword); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { const auto repo = LocalLogRepository(TMPDirPathProvider, badPassword); },
+        std::runtime_error);
 }


### PR DESCRIPTION
the map was only used to map dates to a bool, so it's just a plain set. and with the move to c++23, we have acces to std::chrono::month_day.

`std::set<std::chrono::month_day>` does the job just as good if not better but with less code to maintain.

Besides that, the 'date map' variables and members are renamed to just 'dates' as they are not maping a date to anything, just containing a list of dates.